### PR TITLE
useFormValidation accepts unknown

### DIFF
--- a/.changeset/poor-ravens-allow.md
+++ b/.changeset/poor-ravens-allow.md
@@ -1,0 +1,5 @@
+---
+"@atomicsmash/react": minor
+---
+
+Allow unknown types for setValidationState in useFormValidation.

--- a/packages/react/src/hooks/useFormValidation.ts
+++ b/packages/react/src/hooks/useFormValidation.ts
@@ -14,7 +14,7 @@ export function useFormValidation<SchemaType extends SomeZodObject>(
 		| {
 				type: "update_field";
 				fieldName: string;
-				fieldValue: string;
+				fieldValue: unknown;
 				customSchema?: ZodTypeAny;
 		  }
 		| {
@@ -114,7 +114,7 @@ export function useFormValidation<SchemaType extends SomeZodObject>(
 				customSchema = undefined,
 			}: {
 				fieldName: string;
-				fieldValue: string;
+				fieldValue: unknown;
 				customSchema?: ZodTypeAny;
 			}) => {
 				setFormErrorState({

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
 	"extends": "./tsconfig.json",
-	"exclude": ["src/tests/**/*"]
+	"exclude": ["src/tests/**/*", "**/*.test.*"]
 }


### PR DESCRIPTION
Let useFormValidation accept unknown typed values to setValidationState. It doesn't matter because we just pass that value straight to zod for parsing, and allows us to be more accurate with our form validation schemas.

(no more needing `z.union([z.literal(true), z.literal("true")]);` for required checkboxes! Woo 😄 )