### PR TITLE
Remove classes from primative

### DIFF
--- a/.changeset/old-starfishes-compete.md
+++ b/.changeset/old-starfishes-compete.md
@@ -1,0 +1,5 @@
+---
+"@atomicsmash/react": patch
+---
+
+Remove classes and class merging from Conditional

--- a/package-lock.json
+++ b/package-lock.json
@@ -22082,16 +22082,6 @@
 				"node": ">=10.0.0"
 			}
 		},
-		"node_modules/tailwind-merge": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-1.13.2.tgz",
-			"integrity": "sha512-R2/nULkdg1VR/EL4RXg4dEohdoxNUJGLMnWIQnPKL+O9Twu7Cn3Rxi4dlXkDzZrEGtR+G+psSXFouWlpTyLhCQ==",
-			"peer": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/dcastil"
-			}
-		},
 		"node_modules/tannin": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
@@ -24368,13 +24358,12 @@
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"remix-utils": "^6.4.0",
-				"tailwind-merge": "^1.13.1",
 				"zod": "^3.21.4"
 			}
 		},
 		"packages/test-utils": {
 			"name": "@atomicsmash/test-utils",
-			"version": "0.1.0",
+			"version": "1.1.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@axe-core/playwright": "^4.7.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -57,7 +57,6 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"remix-utils": "^6.4.0",
-		"tailwind-merge": "^1.13.1",
 		"zod": "^3.21.4"
 	},
 	"dependencies": {

--- a/packages/react/src/components/Conditional.tsx
+++ b/packages/react/src/components/Conditional.tsx
@@ -6,7 +6,6 @@ import {
 	useContext,
 	useEffect,
 } from "react";
-import { twMerge } from "tailwind-merge";
 import { useOptionalExternalState } from "../hooks/useOptionalExternalState";
 import { Pretty } from "../shared/types";
 
@@ -88,7 +87,7 @@ export type TriggerProps = {
 		| React.ReactNode;
 } & Omit<ComponentPropsWithRef<"button">, "children">;
 export const Trigger = forwardRef<HTMLButtonElement, TriggerProps>(
-	function Trigger({ asChild, className, children }, forwardedRef) {
+	function Trigger({ asChild, children, ...props }, forwardedRef) {
 		const Comp = asChild ? Slot : "button";
 		const isShowingField = useContext(IsShowingContext);
 		const setIsShowingField = useContext(SetIsShowingContext);
@@ -100,9 +99,9 @@ export const Trigger = forwardRef<HTMLButtonElement, TriggerProps>(
 		}
 		return (
 			<Comp
+				{...props}
 				ref={forwardedRef}
 				type="button"
-				className={twMerge("group/conditional_input", className)}
 				onClick={() => setIsShowingField(!isShowingField)}
 			>
 				{typeof children === "function"
@@ -129,10 +128,9 @@ export const TrueContent = forwardRef<HTMLDivElement, ContentProps>(
 		return (
 			<Comp
 				{...divProps}
-				className={twMerge(
-					!isShowingField && conditionalType === "display" ? hideClass : "",
-					divProps.className,
-				)}
+				className={`${
+					!isShowingField && conditionalType === "display" ? hideClass : ""
+				}${divProps.className ? ` ${divProps.className}` : ""}`}
 				ref={forwardedRef}
 			>
 				{children}
@@ -152,10 +150,9 @@ export const FalseContent = forwardRef<HTMLDivElement, ContentProps>(
 		return (
 			<Comp
 				{...divProps}
-				className={twMerge(
-					isShowingField && conditionalType === "display" ? hideClass : "",
-					divProps.className,
-				)}
+				className={`${
+					isShowingField && conditionalType === "display" ? hideClass : ""
+				}${divProps.className ? ` ${divProps.className}` : ""}`}
 				ref={forwardedRef}
 			>
 				{children}


### PR DESCRIPTION
The goal of this PR is to remove all classes from the react components. These components are intended to be primitive, meaning no styling is provided, so classnames are unnecessary. This was already the case with most classes, however there are a few which were hanging around.
As a side-effect of removing all classnames, we no longer need to merge tailwind classes, so we can remove the tailwind-merge dependency.