### PR TITLE
Fix at rule order

### DIFF
--- a/.changeset/eager-symbols-retire.md
+++ b/.changeset/eager-symbols-retire.md
@@ -1,0 +1,5 @@
+---
+"@atomicsmash/coding-standards": patch
+---
+
+Fix at rule order so non-block at rules are first in order

--- a/packages/coding-standards/stylelint/base.cjs
+++ b/packages/coding-standards/stylelint/base.cjs
@@ -16,10 +16,17 @@ const commonRules = {
 		},
 	],
 	"order/order": [
+		{
+			type: "at-rule",
+			hasBlock: false,
+		},
 		"custom-properties",
 		"dollar-variables",
 		"declarations",
-		"at-rules",
+		{
+			type: "at-rule",
+			hasBlock: true,
+		},
 		"rules",
 	],
 	"selector-class-pattern": [

--- a/packages/coding-standards/stylelint/base.mjs
+++ b/packages/coding-standards/stylelint/base.mjs
@@ -16,10 +16,17 @@ const commonRules = {
 		},
 	],
 	"order/order": [
+		{
+			type: "at-rule",
+			hasBlock: false,
+		},
 		"custom-properties",
 		"dollar-variables",
 		"declarations",
-		"at-rules",
+		{
+			type: "at-rule",
+			hasBlock: true,
+		},
 		"rules",
 	],
 	"selector-class-pattern": [


### PR DESCRIPTION
This PR changes the at rule order so that at rules without a block e.g. `@apply` or `@extend` come first, and the at rules with a block e.g. `@media` or `@supports` come after declarations but before rules.

e.g.
Previously:
```css
.class {
  margin: 1rem;
  @media screen {}
  @extend %other_style;
  .other-class {}
}
```
Now:
```css
.class {
  @extend %other_style;
  margin: 1rem;
  @media screen {}
  .other-class {}
}
```