### PR TITLE
Improve scss alias handling

### DIFF
--- a/.changeset/fifty-worms-watch.md
+++ b/.changeset/fifty-worms-watch.md
@@ -1,0 +1,6 @@
+---
+"@atomicsmash/compiler": minor
+"@atomicsmash/cli": minor
+---
+
+Allow customising of scss aliases with scssAliases.config.ts file

--- a/.changeset/neat-aliens-stick.md
+++ b/.changeset/neat-aliens-stick.md
@@ -1,0 +1,6 @@
+---
+"@atomicsmash/compiler": minor
+"@atomicsmash/cli": minor
+---
+
+Add Launchpad alias to default scss aliases

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { Options } from "sass";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
@@ -18,3 +19,8 @@ await yargsInstance
 	.alias("v", "version")
 	.strict(true)
 	.parse();
+
+export type SCSSAliases = {
+	loadPaths?: Options<"async">["loadPaths"];
+	importers?: Options<"async">["importers"];
+};

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1,2 +1,8 @@
+import type { Options } from "sass";
 // export { config } from "./config";
 // export { config as default } from "./config";
+
+export type SCSSAliases = {
+	loadPaths?: Options<"async">["loadPaths"];
+	importers?: Options<"async">["importers"];
+};


### PR DESCRIPTION
This PR updates the existing scss aliases to include Launchpad, and also provides the ability to modify the scss aliases per project with a config file.

Example scssAliases.config.ts:

```ts
import type { SCSSAliases } from "@atomicsmash/cli";
import { pathToFileURL } from "node:url";
import { resolve } from "node:path";

export default {
  importers: [
    // Launchpad alias is already available, but this removes the sitecss alias to prevent usage.
    {
      findFileUrl(url) {
        if (!url.startsWith("launchpad:")) return null;
        const pathname = url.substring(10);
        return pathToFileURL(
          `${resolve(process.cwd(), "public/wp-content/themes/launchpad/src/styles")}${pathname.startsWith("/") ? pathname : `/${pathname}`}`,
        );
      },
    },
  ],
} satisfies SCSSAliases;

```

Example usage:
```scss
@use "launchpad:some-folder/partial";
```