### PR TITLE
better handle projects with fixed theme names

### DIFF
--- a/.changeset/ninety-lands-decide.md
+++ b/.changeset/ninety-lands-decide.md
@@ -1,0 +1,5 @@
+---
+"@atomicsmash/cli": patch
+---
+
+Better handle projects with fixed theme names

--- a/packages/cli/src/commands/pull-database.ts
+++ b/packages/cli/src/commands/pull-database.ts
@@ -35,7 +35,7 @@ export async function handler() {
 	} else if (!stagingUrl) {
 		throw new Error("STAGING_URL is missing from .env file.");
 	} else {
-		const { themeName } = smashConfig;
+		const { projectName } = smashConfig;
 		const stopRunningMessage = startRunningMessage(
 			"Pulling database from staging",
 		);
@@ -62,7 +62,7 @@ export async function handler() {
 
 						rl.on("line", (line) => {
 							writeStream.write(
-								line.replaceAll(stagingUrl, `//${themeName}.test`) + "\n",
+								line.replaceAll(stagingUrl, `//${projectName}.test`) + "\n",
 							);
 						});
 

--- a/packages/cli/src/commands/setup-database.ts
+++ b/packages/cli/src/commands/setup-database.ts
@@ -25,13 +25,13 @@ export async function handler() {
 			"Unable to determine project setup information. Please add a smash.config.ts file with the required info.",
 		);
 	} else {
-		const { themeName } = smashConfig;
+		const { projectName, themeFolderName } = smashConfig;
 		const stopRunningMessage = startRunningMessage("Initialising database");
 		performance.mark("Start");
 		await execute("wp db create")
 			.then(() => {
 				return execute(
-					`wp core install --url=http://${process.env.CI ? "127.0.0.1" : `${themeName}.test`}/ --title=Temp --admin_user=Bot --admin_email=fake@fake.com --admin_password=password`,
+					`wp core install --url=http://${process.env.CI ? "127.0.0.1" : `${projectName}.test`}/ --title=Temp --admin_user=Bot --admin_email=fake@fake.com --admin_password=password`,
 				);
 			})
 			.then(() => {
@@ -70,7 +70,7 @@ export async function handler() {
 						),
 					)})`,
 				);
-				return execute(`wp theme activate ${themeName}`);
+				return execute(`wp theme activate ${themeFolderName}`);
 			})
 			.then(async () => {
 				performance.mark("theme");

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -28,7 +28,7 @@ export async function handler() {
 			"Unable to determine project setup information. Please add a smash.config.ts file with the required info.",
 		);
 	} else {
-		const { themeName, composerInstallPaths, npmInstallPaths } = smashConfig;
+		const { projectName, composerInstallPaths, npmInstallPaths } = smashConfig;
 		const stopRunningMessage = startRunningMessage("Running setup");
 		performance.mark("Start");
 		await Promise.allSettled([
@@ -83,7 +83,7 @@ export async function handler() {
 									.then(() => true)
 									.catch(() => false)
 							) {
-								await execute(`valet link ${themeName} --secure --isolate`)
+								await execute(`valet link ${projectName} --secure --isolate`)
 									.then(() => {
 										console.log(
 											`Valet is linked, secured and isolated. (${convertMeasureToPrettyString(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,8 +6,9 @@ export type SCSSAliases = {
 };
 
 export type SmashConfig = {
-	themeName: string;
+	projectName: string;
 	themePath: string;
+	themeFolderName?: string;
 	assetsOutputFolder?: string;
 	npmInstallPaths?: string[];
 	composerInstallPaths?: string[];

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -138,6 +138,7 @@ export async function getSmashConfig() {
 			if (isValidSmashConfig(config)) {
 				return {
 					scssAliases: getDefaultSCSSAliases(config.themePath),
+					themeFolderName: config.projectName,
 					...config,
 					// Normalize and resolve paths to cwd.
 					npmInstallPaths:
@@ -181,8 +182,9 @@ export async function getSmashConfig() {
 				"Using env vars for theme name and path is deprecated and will be removed in a future version. Create a smash.config.ts file with the relevant properties in it instead.",
 			);
 			const defaultConfig: Required<SmashConfig> = {
-				themeName,
+				projectName: themeName,
 				themePath,
+				themeFolderName: themeName,
 				assetsOutputFolder: "dist",
 				npmInstallPaths: [],
 				composerInstallPaths: [],


### PR DESCRIPTION
I changed "themeName" to "projectName" to prevent confusion and added an optional override for the theme folder name if needed, which defaults to the project name if not provided.